### PR TITLE
Add Read-Only Allow system call

### DIFF
--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -39,7 +39,7 @@
 //! understand its function and how it interacts with `subscribe`.
 
 use crate::callback::{AppId, Callback};
-use crate::mem::{AppSlice, Shared};
+use crate::mem::{AppSlice, Shared, SharedRO};
 use crate::returncode::ReturnCode;
 
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,
@@ -108,6 +108,22 @@ pub trait Driver {
         app: AppId,
         minor_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
+
+    /// `allow_read` lets an application give the driver read-only access to a buffer in the
+    /// application's memory. This returns `ENOSUPPORT` if not used.
+    ///
+    /// The buffer is __shared__ between the application and driver, meaning the
+    /// driver should not rely on the contents of the buffer to remain
+    /// unchanged.
+    #[allow(unused_variables)]
+    fn allow_read(
+        &self,
+        app: AppId,
+        minor_num: usize,
+        slice: Option<AppSlice<SharedRO, u8>>,
     ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -42,7 +42,7 @@ mod tbfheader;
 pub use crate::callback::{AppId, Callback};
 pub use crate::driver::Driver;
 pub use crate::grant::Grant;
-pub use crate::mem::{AppPtr, AppSlice, Private, Shared};
+pub use crate::mem::{AppPtr, AppSlice, Private, Read, ReadWrite, Shared, SharedRO};
 pub use crate::platform::systick::SysTick;
 pub use crate::platform::{mpu, Chip, Platform};
 pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -14,7 +14,7 @@ use crate::common::{Queue, RingBuffer};
 use crate::config;
 use crate::debug;
 use crate::ipc;
-use crate::mem::{AppSlice, Shared};
+use crate::mem::{AppSlice, Shared, SharedRO};
 use crate::platform::mpu::{self, MPU};
 use crate::platform::Chip;
 use crate::returncode::ReturnCode;
@@ -292,7 +292,7 @@ pub trait ProcessType {
 
     // additional memop like functions
 
-    /// Creates an `AppSlice` from the given offset and size in process memory.
+    /// Creates a ReadWrite `AppSlice` from the given offset and size in process memory.
     ///
     /// If `buf_start_addr` is NULL this will have no effect and the return
     /// value will be `None` to signal the capsule to drop the buffer.
@@ -313,6 +313,28 @@ pub trait ProcessType {
         buf_start_addr: *const u8,
         size: usize,
     ) -> Result<Option<AppSlice<Shared, u8>>, ReturnCode>;
+
+    /// Creates a ReadOnly `AppSlice` from the given offset and size in process memory.
+    ///
+    /// If `buf_start_addr` is NULL this will have no effect and the return
+    /// value will be `None` to signal the capsule to drop the buffer.
+    ///
+    /// If the process is not active then this will return an error as it is not
+    /// valid to "allow" a buffer for a process that will not resume executing.
+    /// In practice this case should not happen as the process will not be
+    /// executing to call the allow syscall.
+    ///
+    /// ## Returns
+    ///
+    /// If the buffer is null (a zero-valued offset) this returns `None`,
+    /// signaling the capsule to delete the entry. If the buffer is within the
+    /// process's accessible memory or flash, returns an `AppSlice` wrapping that buffer.
+    /// Otherwise, returns an error `ReturnCode`.
+    fn allow_read(
+        &self,
+        buf_start_addr: *const u8,
+        size: usize,
+    ) -> Result<Option<AppSlice<SharedRO, u8>>, ReturnCode>;
 
     /// Get the first address of process's flash that isn't protected by the
     /// kernel. The protected range of flash contains the TBF header and
@@ -1131,6 +1153,48 @@ impl<C: Chip> ProcessType for Process<'a, C> {
         }
     }
 
+    fn allow_read(
+        &self,
+        buf_start_addr: *const u8,
+        size: usize,
+    ) -> Result<Option<AppSlice<SharedRO, u8>>, ReturnCode> {
+        if !self.is_active() {
+            // Do not modify an inactive process.
+            return Err(ReturnCode::FAIL);
+        }
+
+        match NonNull::new(buf_start_addr as *mut u8) {
+            None => {
+                // A null buffer means pass in `None` to the capsule
+                Ok(None)
+            }
+            Some(buf_start) => {
+                if self.in_app_owned_memory(buf_start_addr, size) {
+                    // Valid slice, we need to adjust the app's watermark
+                    // note: in_app_owned_memory ensures this offset does not wrap
+                    let buf_end_addr = buf_start_addr.wrapping_add(size);
+                    let new_water_mark = max(self.allow_high_water_mark.get(), buf_end_addr);
+                    self.allow_high_water_mark.set(new_water_mark);
+
+                    // The `unsafe` promise we should be making here is that this
+                    // buffer is inside of app memory and that it does not create any
+                    // aliases (i.e. the same buffer has not been `allow`ed twice).
+                    //
+                    // TODO: We do not currently satisfy the second promise.
+                    let slice = unsafe { AppSlice::new(buf_start, size, self.appid()) };
+                    Ok(Some(slice))
+                } else if self.in_app_ro_memory(buf_start_addr, size) {
+                    // The `unsafe` promise we should be making here is that this
+                    // buffer is inside of app memory
+                    let slice = unsafe { AppSlice::new(buf_start, size, self.appid()) };
+                    Ok(Some(slice))
+                } else {
+                    Err(ReturnCode::EINVAL)
+                }
+            }
+        }
+    }
+
     fn alloc(&self, size: usize, align: usize) -> Option<NonNull<u8>> {
         // Do not modify an inactive process.
         if !self.is_active() {
@@ -1849,6 +1913,19 @@ impl<C: 'static + Chip> Process<'a, C> {
         buf_end_addr >= buf_start_addr
             && buf_start_addr >= self.mem_start()
             && buf_end_addr <= self.app_break.get()
+    }
+
+    /// Checks if the buffer represented by the passed in base pointer and size
+    /// are within the memory bounds currently exposed to the processes (i.e.
+    /// ending at `app_break`. If this method returns true, the buffer
+    /// is guaranteed to be accessible to the process and to not overlap with
+    /// the grant region.
+    fn in_app_ro_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
+        let buf_end_addr = buf_start_addr.wrapping_add(size);
+
+        buf_end_addr >= buf_start_addr
+            && buf_start_addr >= self.flash_non_protected_start()
+            && buf_end_addr <= self.flash_end()
     }
 
     /// Reset all `grant_ptr`s to NULL.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -525,6 +525,42 @@ impl Kernel {
                                     }
                                     process.set_syscall_return_value(res.into());
                                 }
+                                Syscall::ALLOWRO {
+                                    driver_number,
+                                    subdriver_number,
+                                    allow_address,
+                                    allow_size,
+                                } => {
+                                    let res = platform.with_driver(driver_number, |driver| {
+                                        match driver {
+                                            Some(d) => {
+                                                match process.allow_read(allow_address, allow_size)
+                                                {
+                                                    Ok(oslice) => d.allow_read(
+                                                        process.appid(),
+                                                        subdriver_number,
+                                                        oslice,
+                                                    ),
+                                                    Err(err) => err, /* memory not valid */
+                                                }
+                                            }
+                                            None => ReturnCode::ENODEVICE,
+                                        }
+                                    });
+                                    if config::CONFIG.trace_syscalls {
+                                        debug!(
+                                            "[{:?}] allow_read({:#x}, {}, @{:#x}, {:#x}) = {:#x} = {:?}",
+                                            process.appid(),
+                                            driver_number,
+                                            subdriver_number,
+                                            allow_address as usize,
+                                            allow_size,
+                                            usize::from(res),
+                                            res
+                                        );
+                                    }
+                                    process.set_syscall_return_value(res.into());
+                                }
                             }
                         }
                         Some(ContextSwitchReason::TimesliceExpired) => {

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -33,10 +33,20 @@ pub enum Syscall {
         arg1: usize,
     },
 
-    /// Share a memory buffer with the kernel.
+    /// Share a memory buffer read-write with the kernel.
     ///
     /// SVC_NUM = 3
     ALLOW {
+        driver_number: usize,
+        subdriver_number: usize,
+        allow_address: *mut u8,
+        allow_size: usize,
+    },
+
+    /// Share a memory buffer read-only with the kernel.
+    ///
+    /// SVC_NUM = 5
+    ALLOWRO {
         driver_number: usize,
         subdriver_number: usize,
         allow_address: *mut u8,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a read-only allow system call (#1274), in which a process allows a driver to access some of it's memory read-only. This enables a process to share flash/rom memory, as well as RAM, and lets it make stronger assumptions about what the driver might do with the memory (in particular it can't modify it).

To accomplish this simply, the PR introduces a new marker type for `AppPtr` and `AppSlice` called `SharedRO` which marks it read only. This is then used to differentiate implementations of `AppPtr` and `AppSlice` for `Deref` and `DerefMut` and `AsRef` and `AsMut`, respectively. In the kernel, the process module creates a `AppSlice<SharedRO, T>` by checking that the passed in buffer is _either_ in the process's owned memory _or_ in non-protected flash.

Finally, the PR implements the ALLOWRO system call for the capsule driver by simply forwarding regular allow calls for the write path to `allow_read`.

### Testing Strategy

I tested this by running the `c_hello` app with the modified kernel. Which is to say, not yet rigorously.

### TODO or Help Wanted

The major question I have is whether to use the next largest system call number (5), or to re-order system call numbers such that allow (3) and allowro are next to each other---currently MEMOP is in between them, as the order of system call numbers is simply the order in which they were added chronologically.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
